### PR TITLE
AST representation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,4 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
-.stack.yaml.lock
+stack.yaml.lock

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+.stack.yaml.lock

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,5 +1,4 @@
 module Main where
 
 main :: IO ()
-main = do
-  putStrLn "hello world"
+main = putStrLn "hello world"

--- a/src/Program.hs
+++ b/src/Program.hs
@@ -1,0 +1,51 @@
+module Program where
+
+import qualified Data.Text as T
+import Text.Megaparsec (SourcePos)
+
+
+type Name = T.Text
+
+data Located a = Located
+    { location  :: SourcePos
+    , unlocated :: a
+    }
+
+newtype Program = Program 
+    { getModules :: [Module] 
+    }
+
+data ModuleName = ModuleName
+    { modulePrefix :: [Name]
+    , moduleName   :: Name
+    }
+
+data Module = Module 
+    { moduleId      :: ModuleName
+    , modulePath    :: FilePath
+    , moduleImports :: [Import]
+    , moduleExports :: Maybe [Located Name]
+    , moduleDefs    :: [LetDef]
+    }
+
+data Import = Import
+    { source      :: Module
+    , importLoc   :: SourcePos
+    , importNames :: Maybe [Located Name]
+    }
+
+type LetDef = Int
+
+data Expr 
+    = IntLit Int SourcePos
+    | CharLit Char SourcePos
+    | FloatLit Double SourcePos
+    | StringLit T.Text SourcePos
+    | BoolLit Bool SourcePos
+    | Unit SourcePos
+    | And Expr Expr SourcePos
+    | Or Expr Expr SourcePos
+    | If Expr Expr Expr SourcePos
+
+instance Functor Located where
+    fmap f (Located loc a) = Located loc $ f a

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -117,6 +117,7 @@ data PrimType
     | CharT
     | BoolT
     | UnitT
+    | CPtrT
 
 data TypeCase
     = TypeCaseRecord ConstructorName RecordType SourcePos
@@ -134,7 +135,7 @@ data RecordField = RecordField
 data KindSig
     = TypeKind
     -- ^ the * kind
-    | TypeConstructorKind
+    | TypeConstructorKind KindSig KindSig
     -- ^ the (->) kind
 
 data Type

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -42,7 +42,7 @@ data TopLevelDef
     | InstanceDef Instance
 
 data LetDef = LetDef
-    { letPattern :: Pattern
+    { letPattern :: LetPattern
     , letTypeSig :: Maybe TypeSig
     , letExpr    :: Expr
     , letLoc     :: SourcePos
@@ -50,27 +50,54 @@ data LetDef = LetDef
 
 data Expr 
     = IntLit Int SourcePos
+    -- ^ 64 bit signed integers 
     | CharLit Char SourcePos
+    -- ^ single unicode character
     | FloatLit Double SourcePos
+    -- ^ double precision floating number
     | StringLit T.Text SourcePos
+    -- ^ non-format string literal
     | BoolLit Bool SourcePos
+    -- ^ boolean value
     | UnitLit SourcePos
+    -- ^ () value
     | Var Name SourcePos
+    -- ^ an identifier (note th)
     | And Expr Expr SourcePos
+    -- ^ 'and' boolean operator with its left and right operands
     | Or Expr Expr SourcePos
+    -- ^ 'or' boolean operator with its left and right operands
     | If Expr Expr Expr SourcePos
+    -- ^ conditional expression with the condition, consequence and alternative
     | Block [Expr] SourcePos
+    -- ^ list of expressions to be evaluated in order
     | LetIn LetDef Expr
+    -- ^ local definition. Binds only in the Expr following it. Does not
+    --   store SourcePos as it is stored both in LetDef and (maybe) in Expr
     | MultiLet [LetDef] Expr
-    | Lambda Pattern Expr SourcePos
+    -- ^ multiple mutually recursive local definitions.
+    | Lambda [Pattern] Expr (Maybe Name) SourcePos
+    -- ^ lambda expression with the list of bindings (patterns) and
+    --   the expression to evaluate upon the function call.
+    --   May remember the name if it was defined in 'let'-definiiton.
     | Tuple [Expr] SourcePos
-    | List [Expr] SourcePos
+    -- ^ non-empty list of expressions. Tuples of different arity
+    --   have different types.
     | Array [Expr] SourcePos
-    | App Expr Expr
-    | Match PatternMatching
+    -- ^ array literal.
+    | App Expr [Expr]
+    -- ^ application of an expression to some expresions.
+    | Match Expr [MatchCase] SourcePos
+    -- ^ pattern matching of Expr with a list of patterns. First matching
+    --   pattern is choosen.
     | Extern Name Name SourcePos
+    -- ^ used to import foreign functions from shared libraries.
     | Internal Name SourcePos
+    -- ^ built-in compiler value.
     | AnnotatedExpr Expr TypeSig SourcePos
+    -- ^ expression with the type given explicitly (like 2 :: Int in Haskell).
+    | FormatString [FormatExpr] SourcePos
+    -- ^ interpolated string
 
 instance Functor Located where
     fmap f (Located loc a) = Located loc $ f a

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -1,4 +1,4 @@
-module Program where
+module Syntax where
 
 import qualified Data.Text as T
 import Text.Megaparsec (SourcePos)
@@ -25,16 +25,28 @@ data Module = Module
     , modulePath    :: FilePath
     , moduleImports :: [Import]
     , moduleExports :: Maybe [Located Name]
-    , moduleDefs    :: [LetDef]
+    , moduleDefs    :: [TopLevelDef]
     }
 
 data Import = Import
-    { source      :: Module
-    , importLoc   :: SourcePos
-    , importNames :: Maybe [Located Name]
+    { source    :: Module
+    , importLoc :: SourcePos
+    , importIds :: Maybe [Located Name]
     }
 
-type LetDef = Int
+data TopLevelDef
+    = TopLevelLet LetDef
+    | AliasDef    TypeAlias
+    | TypeDef     TypeDecl
+    | ClassDef    Class
+    | InstanceDef Instance
+
+data LetDef = LetDef
+    { letPattern :: Pattern
+    , letTypeSig :: Maybe TypeSig
+    , letExpr    :: Expr
+    , letLoc     :: SourcePos
+    }
 
 data Expr 
     = IntLit Int SourcePos
@@ -42,10 +54,23 @@ data Expr
     | FloatLit Double SourcePos
     | StringLit T.Text SourcePos
     | BoolLit Bool SourcePos
-    | Unit SourcePos
+    | UnitLit SourcePos
+    | Var Name SourcePos
     | And Expr Expr SourcePos
     | Or Expr Expr SourcePos
     | If Expr Expr Expr SourcePos
+    | Block [Expr] SourcePos
+    | LetIn LetDef Expr
+    | MultiLet [LetDef] Expr
+    | Lambda Pattern Expr SourcePos
+    | Tuple [Expr] SourcePos
+    | List [Expr] SourcePos
+    | Array [Expr] SourcePos
+    | App Expr Expr
+    | Match PatternMatching
+    | Extern Name Name SourcePos
+    | Internal Name SourcePos
+    | AnnotatedExpr Expr TypeSig SourcePos
 
 instance Functor Located where
     fmap f (Located loc a) = Located loc $ f a

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -124,7 +124,7 @@ data TypeCase
     = TypeCaseRecord ConstrName RecordType SourcePos
     -- ^ constructor of a record
     | TypeCase ConstrName [TypeSig] SourcePos
-    -- ^ normal constructor (eg. 'Just a')
+    -- ^ normal constructor (e.g. 'Just a')
 
 newtype RecordType = RecordType [RecordField]
 
@@ -141,19 +141,19 @@ data KindSig
 
 data Type
     = TypeVariable  TypeVar
-    -- ^ polymorphic type (eg. 'a', 'b', 't')
+    -- ^ polymorphic type (e.g. 'a', 'b', 't')
     | PrimitiveType PrimType
     -- ^ One of the built-in primitive types
     | FunctionType Type Type
     -- ^ (a -> b) type
     | NonPrimType TypeName
-    -- ^ non-primitive types without parameters (eg. Integer)
+    -- ^ non-primitive types without parameters (e.g. Integer)
     | ParamType TypeName [Type]
-    -- ^ concrete type with parameters (eg. 'Maybe a', '[a]', 'Array Int')
+    -- ^ concrete type with parameters (e.g. 'Maybe a', '[a]', 'Array Int')
     | PolymorphicParamType TypeVar [Type]
-    -- ^ polymorphic type with parameters (eg. '(m a)', '(t Int)')
+    -- ^ polymorphic type with parameters (e.g. '(m a)', '(t Int)')
     | TupleType [Type]
-    -- ^ tuple of types (eg. '(Int, a, Float)')
+    -- ^ tuple of types (e.g. '(Int, a, Float)')
 
 data PrimExpr
     = IntLit Int
@@ -222,15 +222,17 @@ data MatchCase = MatchCase
 
 data Pattern
     = ConstPattern PrimExpr SourcePos
-    -- ^ a primitive constant (eg. 1)
+    -- ^ a primitive constant (e.g. 1)
     | TuplePattern [Pattern] SourcePos
-    -- ^ a tupple of patterns (eg. (x, _))
+    -- ^ a tupple of patterns (e.g. (x, _))
     | ConstructorPattern ConstrName [Pattern] SourcePos
-    -- ^ a constructor applied to patterns (eg. 'Just x', 'Nothing', 'x:xs')
+    -- ^ a constructor applied to patterns (e.g. 'Just x', 'Nothing', 'x:xs')
     | WildcardPattern SourcePos
     -- ^ a pattern that matches everything but discards the value ('_')
     | VarPattern Name SourcePos
     -- ^ a pattern that matches everything and binds the value to the name
+    | NamedPattern Name Pattern SourcePos
+    -- ^ a pattern that is named as a whole (e.g. 'tree@(Node left x right)')
 
 instance Functor Located where
     fmap f (Located loc a) = Located loc $ f a

--- a/zoria-lang.cabal
+++ b/zoria-lang.cabal
@@ -16,5 +16,8 @@ extra-source-files:  README.md
 executable zoriac
   hs-source-dirs:      src
   main-is:             Main.hs
+  other-modules:       Program
   default-language:    Haskell2010
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.7 && < 5,
+                       text >= 1.2.4.0,
+                       megaparsec >= 8.0.0

--- a/zoria-lang.cabal
+++ b/zoria-lang.cabal
@@ -16,7 +16,7 @@ extra-source-files:  README.md
 executable zoriac
   hs-source-dirs:      src
   main-is:             Main.hs
-  other-modules:       Program
+  other-modules:       Syntax
   default-language:    Haskell2010
   build-depends:       base >= 4.7 && < 5,
                        text >= 1.2.4.0,


### PR DESCRIPTION
Added the types for the internal representation of the programs.
Now we can work on the parser and the interpreter+compiler simultaneously.

The definitions might have to change in the future.