### PR TITLE
Command line option parsing.

### DIFF
--- a/src/GetOpt.hs
+++ b/src/GetOpt.hs
@@ -1,0 +1,68 @@
+module GetOpt where
+
+import System.Console.GetOpt
+import qualified Data.Text as T
+import System.Exit (exitWith, ExitCode(ExitSuccess))
+import System.Environment (getProgName)
+
+data Arguments = Arguments
+    { argsOptions :: Options
+    , argsInput   :: FilePath
+    }
+
+data Options = Options
+    { optOutput  :: FilePath
+    , optModules :: [ModulePath]
+    }
+
+data ModulePath = ModulePath
+    { optModName :: T.Text
+    , optModPath :: FilePath
+    }
+
+defaultOptions :: Options
+defaultOptions = Options
+    { optModules = []
+    , optOutput  = "a.out"
+    }
+
+addModuleOpt :: String -> Options -> Options
+addModuleOpt modOpt opts = opts { optModules = modPath : modules }
+  where
+    modules = optModules opts
+    modPath = undefined
+
+options :: [OptDescr (Options -> IO Options)]
+options = 
+    [ Option "o" ["output"] 
+        (ReqArg (\arg opts -> return opts { optOutput = arg }) "FILE")
+        "Output file"
+    , Option "V" ["version"] 
+        (NoArg (\_ -> do
+            putStrLn "Version 0.1.0.0" -- TODO: embed the version from *.cabal
+            exitWith ExitSuccess
+        ))
+        "Print program version"
+    , Option "h" ["help"]
+        (NoArg (\_ -> do
+            progName <- getProgName
+            putStrLn (usageInfo progName options)
+            exitWith ExitSuccess
+        ))
+        "Show help"
+    , Option "m" ["module"]
+        (ReqArg (\arg opts -> return $ addModuleOpt arg opts) "MODULE:PATH")
+        "Extern module path"
+    ]
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/GetOpt.hs
+++ b/src/GetOpt.hs
@@ -2,7 +2,7 @@ module GetOpt
     ( Options(..)
     , Arguments(..)
     , ModulePath(..)
-    , parseOptions
+    , getOptions
     )
 where
 
@@ -85,8 +85,8 @@ options =
         "Extern module path"
     ]
 
-parseOptions :: IO Options
-parseOptions = do
+getOptions :: IO Options
+getOptions = do
     args <- getArgs
     let (optActions, nonOptions, errors) = getOpt Permute options args
     foldl (>>=) (return defaultOptions) optActions

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,4 +1,9 @@
 module Main where
 
+import GetOpt
+
+
 main :: IO ()
-main = putStrLn "hello world"
+main = do
+    options <- getOptions
+    print options

--- a/zoria-lang.cabal
+++ b/zoria-lang.cabal
@@ -17,6 +17,7 @@ executable zoriac
   hs-source-dirs:      src
   main-is:             Main.hs
   other-modules:       Syntax
+                       GetOpt
   default-language:    Haskell2010
   build-depends:       base >= 4.7 && < 5,
                        text >= 1.2.4.0,


### PR DESCRIPTION
Added command line arguments parsing using System.Console.GetOpt.

Currently the following arguments are valid:
- `-h or --help` -- prints the usage instructions and exits.
- `-V or --version` -- prints the current version and exits.
- `-o or --output` -- used to specify the output file for compilation.
- `-m or --module` -- used to specify external module paths (for example `--module=Foo:/lib/bar/foo`)

It should be easy to extend the set of possible flags to accommodate future requirements.