### PR TITLE
Fixed the import/export lists.

### DIFF
--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -20,8 +20,8 @@ data Located a = Located
     }
   deriving Show
 
-newtype Program = Program 
-    { programModules :: [Module] 
+newtype Program a = Program 
+    { programModules :: [Module a]
     }
   deriving Show
 
@@ -31,17 +31,17 @@ data ModuleId = ModuleId
     }
   deriving Show
 
-data Module = Module 
+data Module a = Module 
     { moduleId      :: ModuleId
     , modulePath    :: FilePath
     , moduleImports :: [Import]
     , moduleExports :: Maybe [Located ImportedValue]
-    , moduleDefs    :: [TopLevelDef]
+    , moduleDefs    :: [TopLevelDef a]
     }
   deriving Show
 
 data Import = Import
-    { source    :: Module
+    { source    :: ModuleId
     , importLoc :: SourcePos
     , importIds :: Maybe [Located ImportedValue]
     }
@@ -51,21 +51,21 @@ data ImportedValue
     = ImportedIdentifier Identifier 
     -- ^ imported variable (e.g. '(>>=)', 'map')
     | ImportedType TypeName [ConstructorName]
-    -- ^ type and constructor import (e.g. Maybe(Nothing), Either(), Map)
+    -- ^ type and constructor import (e.g. Maybe(Nothing), Either(), Map(..))
   deriving Show
 
-data TopLevelDef
-    = TopLevelLet LetDef
+data TopLevelDef a
+    = TopLevelLet (LetDef a)
     | AliasDef    TAlias
     | TypeDef     TDef
     | ClassDef    Class
-    | InstanceDef Instance
+    | InstanceDef (Instance a)
   deriving Show
 
-data LetDef = LetDef
-    { letPattern :: LetPattern
+data LetDef a = LetDef
+    { letPattern :: LetPattern a
     , letTypeSig :: Maybe TypeSig
-    , letExpr    :: Expr
+    , letExpr    :: Expr a
     , letLoc     :: SourcePos
     }
   deriving Show
@@ -110,20 +110,20 @@ data Constraint = Constraint
     }
   deriving Show
 
-data Instance = Instance
+data Instance a = Instance
     { instanceClass   :: TypeName
     , instanceType    :: TypeSig
-    , instanceMembers :: [LetDef]
+    , instanceMembers :: [LetDef a]
     , instanceLoc     :: SourcePos
     }
   deriving Show
 
-data LetPattern
+data LetPattern a
     = FuncPattern 
         { letFuncName :: Identifier
-        , letFuncArgs :: [Pattern]
+        , letFuncArgs :: [Pattern a]
         }
-    | LetPattern Pattern
+    | LetPattern (Pattern a)
   deriving Show
 
 data TypeSig = TypeSig
@@ -197,72 +197,72 @@ data PrimExpr
     -- ^ () value
   deriving Show
 
-data Expr 
-    = Primitive PrimExpr SourcePos
-    | Var Identifier SourcePos
+data Expr a
+    = Primitive PrimExpr SourcePos a
+    | Var Identifier SourcePos a
     -- ^ an identifier
-    | ScopedName ModuleId Identifier SourcePos
+    | ScopedName ModuleId Identifier SourcePos a
     -- ^ name from a module (e.g. `Foo.Bar.x`)
-    | And Expr Expr SourcePos
+    | And (Expr a) (Expr a) SourcePos a
     -- ^ 'and' boolean operator with its left and right operands
-    | Or Expr Expr SourcePos
+    | Or (Expr a) (Expr a) SourcePos a
     -- ^ 'or' boolean operator with its left and right operands
-    | If Expr Expr Expr SourcePos
+    | If (Expr a) (Expr a) (Expr a) SourcePos a
     -- ^ conditional expression with the condition, consequence and alternative
-    | Block [Expr] SourcePos
+    | Block [Expr a] SourcePos a
     -- ^ list of expressions to be evaluated in order
-    | LetIn LetDef Expr
+    | LetIn (LetDef a) (Expr a) a
     -- ^ local definition. Binds only in the Expr following it. Does not
     --   store SourcePos as it is stored both in LetDef and (maybe) in Expr
-    | MultiLetIn [LetDef] Expr
+    | MultiLetIn [LetDef a] (Expr a) a
     -- ^ multiple mutually recursive local definitions.
-    | Lambda [Pattern] Expr (Maybe Identifier) SourcePos
+    | Lambda [Pattern a] (Expr a) (Maybe Identifier) SourcePos a
     -- ^ lambda expression with the list of bindings (patterns) and
     --   the expression to evaluate upon the function call.
     --   May remember the name if it was defined in 'let'-definiiton.
-    | Tuple [Expr] SourcePos
+    | Tuple [Expr a] SourcePos a
     -- ^ non-empty list of expressions. Tuples of different arity
     --   have different types.
-    | Array [Expr] SourcePos
+    | Array [Expr a] SourcePos a
     -- ^ array literal.
-    | App Expr Expr
+    | App (Expr a) (Expr a) a
     -- ^ application of an expression to another expression.
-    | Match Expr [MatchCase] SourcePos
+    | Match (Expr a) [MatchCase a] SourcePos a
     -- ^ pattern matching of Expr with a list of patterns. First matching
     --   pattern is choosen.
-    | Extern FilePath T.Text SourcePos
+    | Extern FilePath T.Text SourcePos a
     -- ^ used to import foreign functions from shared libraries.
-    | Internal Identifier SourcePos
+    | Internal Identifier SourcePos a
     -- ^ built-in compiler value.
-    | AnnotatedExpr Expr TypeSig SourcePos
+    | AnnotatedExpr (Expr a) TypeSig SourcePos a
     -- ^ expression with the type given explicitly (like 2 :: Int in Haskell).
-    | FormatString [FormatExpr] SourcePos
+    | FormatString [FormatExpr a] SourcePos a
     -- ^ string literals and expressions to evaluate, show and concatenate
   deriving Show
 
-data FormatExpr
+data FormatExpr a
     = FmtStr  T.Text
-    | FmtExpr Expr
+    | FmtExpr (Expr a)
   deriving Show
 
-data MatchCase = MatchCase
-    { matchCasePattern :: Pattern
-    , matchCaseExpr    :: Expr
+data MatchCase a = MatchCase
+    { matchCasePattern :: Pattern a
+    , matchCaseExpr    :: Expr a
     }
   deriving Show
 
-data Pattern
-    = ConstPattern PrimExpr SourcePos
+data Pattern a
+    = ConstPattern PrimExpr SourcePos a
     -- ^ a primitive constant (e.g. 1)
-    | TuplePattern [Pattern] SourcePos
+    | TuplePattern [Pattern a] SourcePos a
     -- ^ a tupple of patterns (e.g. (x, _))
-    | ConstructorPattern ConstructorName [Pattern] SourcePos
+    | ConstructorPattern ConstructorName [Pattern a] SourcePos a
     -- ^ a constructor applied to patterns (e.g. 'Just x', 'Nothing', 'x:xs')
-    | WildcardPattern SourcePos
+    | WildcardPattern SourcePos a
     -- ^ a pattern that matches everything but discards the value ('_')
-    | VarPattern Identifier SourcePos
+    | VarPattern Identifier SourcePos a
     -- ^ a pattern that matches everything and binds the value to the name
-    | NamedPattern Identifier Pattern SourcePos
+    | NamedPattern Identifier (Pattern a) SourcePos a
     -- ^ a pattern that is named as a whole (e.g. 'tree@(Node left x right)')
   deriving Show
 

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -4,43 +4,55 @@ import qualified Data.Text as T
 import Text.Megaparsec (SourcePos)
 
 
-newtype Identifier = Identifier T.Text
+newtype Identifier = Identifier T.Text deriving Show
 
-newtype TypeVar = TypeVar T.Text
+newtype TypeVar = TypeVar T.Text deriving Show
 
-newtype ConstructorName = ConstructorName T.Text
+newtype ConstructorName = ConstructorName T.Text deriving Show
 
-newtype TypeName = TypeName T.Text
+newtype TypeName = TypeName T.Text deriving Show
 
-newtype ModName = ModName T.Text
+newtype ModName = ModName T.Text deriving Show
 
 data Located a = Located
     { location  :: SourcePos
     , unlocated :: a
     }
+  deriving Show
 
 newtype Program = Program 
     { programModules :: [Module] 
     }
+  deriving Show
 
 data ModuleId = ModuleId
     { modulePrefix :: [ModName]
     , moduleName   :: ModName
     }
+  deriving Show
 
 data Module = Module 
     { moduleId      :: ModuleId
     , modulePath    :: FilePath
     , moduleImports :: [Import]
-    , moduleExports :: Maybe [Located Identifier]
+    , moduleExports :: Maybe [Located ImportedValue]
     , moduleDefs    :: [TopLevelDef]
     }
+  deriving Show
 
 data Import = Import
     { source    :: Module
     , importLoc :: SourcePos
-    , importIds :: Maybe [Located Identifier]
+    , importIds :: Maybe [Located ImportedValue]
     }
+  deriving Show
+
+data ImportedValue
+    = ImportedIdentifier Identifier 
+    -- ^ imported variable (e.g. '(>>=)', 'map')
+    | ImportedType TypeName [ConstructorName]
+    -- ^ type and constructor import (e.g. Maybe(Nothing), Either(), Map)
+  deriving Show
 
 data TopLevelDef
     = TopLevelLet LetDef
@@ -48,6 +60,7 @@ data TopLevelDef
     | TypeDef     TDef
     | ClassDef    Class
     | InstanceDef Instance
+  deriving Show
 
 data LetDef = LetDef
     { letPattern :: LetPattern
@@ -55,6 +68,7 @@ data LetDef = LetDef
     , letExpr    :: Expr
     , letLoc     :: SourcePos
     }
+  deriving Show
 
 data TAlias = TAlias
     { aliasName   :: TypeName
@@ -63,6 +77,7 @@ data TAlias = TAlias
     , aliasType   :: TypeSig
     , alisLoc     :: SourcePos
     }
+  deriving Show
 
 data TDef = TDef
     { typeDefName   :: TypeName
@@ -71,6 +86,7 @@ data TDef = TDef
     , typeDefCases  :: [TypeCase]
     , typeDefLoc    :: SourcePos
     }
+  deriving Show
 
 data Class = Class
     { className        :: TypeName
@@ -80,16 +96,19 @@ data Class = Class
     , classMembers     :: [ValSig]
     , classLoc         :: SourcePos
     }
+  deriving Show
 
 data ValSig = ValSig
     { valSigName :: Identifier
     , valSigType :: TypeSig
     }
+  deriving Show
 
 data Constraint = Constraint
     { constraintName  :: TypeName
     , constraintParam :: TypeVar
     }
+  deriving Show
 
 data Instance = Instance
     { instanceClass   :: TypeName
@@ -97,6 +116,7 @@ data Instance = Instance
     , instanceMembers :: [LetDef]
     , instanceLoc     :: SourcePos
     }
+  deriving Show
 
 data LetPattern
     = FuncPattern 
@@ -104,11 +124,13 @@ data LetPattern
         , letFuncArgs :: [Pattern]
         }
     | LetPattern Pattern
+  deriving Show
 
 data TypeSig = TypeSig
     { typeSigConstraints :: [Constraint]
     , typeSig            :: Type
     }
+  deriving Show
 
 data PrimType
     = IntT
@@ -118,25 +140,30 @@ data PrimType
     | BoolT
     | UnitT
     | CPtrT
+  deriving Show
 
 data TypeCase
     = TypeCaseRecord ConstructorName RecordType SourcePos
     -- ^ constructor of a record
     | TypeCase ConstructorName [TypeSig] SourcePos
     -- ^ normal constructor (e.g. 'Just a')
+  deriving Show
 
-newtype RecordType = RecordType [RecordField]
+
+newtype RecordType = RecordType [RecordField] deriving Show
 
 data RecordField = RecordField
     { recordFieldName :: Identifier
     , recordFieldType :: TypeSig
     }
+  deriving Show
 
 data KindSig
     = TypeKind
     -- ^ the * kind
     | TypeConstructorKind KindSig KindSig
     -- ^ the (->) kind
+  deriving Show
 
 data Type
     = TypeVariable  TypeVar
@@ -153,6 +180,7 @@ data Type
     -- ^ polymorphic type with parameters (e.g. '(m a)', '(t Int)')
     | TupleType [Type]
     -- ^ tuple of types (e.g. '(Int, a, Float)')
+  deriving Show
 
 data PrimExpr
     = IntLit Int
@@ -167,6 +195,7 @@ data PrimExpr
     -- ^ boolean value
     | UnitLit
     -- ^ () value
+  deriving Show
 
 data Expr 
     = Primitive PrimExpr SourcePos
@@ -209,15 +238,18 @@ data Expr
     -- ^ expression with the type given explicitly (like 2 :: Int in Haskell).
     | FormatString [FormatExpr] SourcePos
     -- ^ string literals and expressions to evaluate, show and concatenate
+  deriving Show
 
 data FormatExpr
     = FmtStr  T.Text
     | FmtExpr Expr
+  deriving Show
 
 data MatchCase = MatchCase
     { matchCasePattern :: Pattern
     , matchCaseExpr    :: Expr
     }
+  deriving Show
 
 data Pattern
     = ConstPattern PrimExpr SourcePos
@@ -232,6 +264,7 @@ data Pattern
     -- ^ a pattern that matches everything and binds the value to the name
     | NamedPattern Identifier Pattern SourcePos
     -- ^ a pattern that is named as a whole (e.g. 'tree@(Node left x right)')
+  deriving Show
 
 instance Functor Located where
     fmap f (Located loc a) = Located loc $ f a


### PR DESCRIPTION
Until now we could only export/import simple identifiers. Now the
types has been extended to allow for type and constructor importing.
Derived Show for all types from Syntax.hs.

Fixes #5 