### PR TITLE
'Utility' module.

### DIFF
--- a/src/Utility.hs
+++ b/src/Utility.hs
@@ -1,0 +1,8 @@
+module Utility where
+
+
+data Position = Position
+    { posOffset :: !Int
+    , posFile   :: !FilePath
+    }
+  deriving Show

--- a/zoria-lang.cabal
+++ b/zoria-lang.cabal
@@ -18,6 +18,7 @@ executable zoriac
   main-is:             Main.hs
   other-modules:       Syntax
                        GetOpt
+                       Utility
   default-language:    Haskell2010
   build-depends:       base >= 4.7 && < 5,
                        text >= 1.2.4.0,


### PR DESCRIPTION
Some things will have to be shared across the entire codebase, so
I created a separate module, which will contain stuff like
useful functions that don't fit in another modules well 
(or would have to be imported from many places).

One of such things is the new 'Position' type that will replace
'SourcePos' from Megaparsec. While SourcePos is a convenient
way to store positions of AST elements, it is unfortunately difficult
to extract while parsing (in a efficient way). Instead we will
simply store the file name and the offset from the beginning. It
will be sufficient to print nice error messages (line and column
numbers can be easily recovered using the offset).

I have replaced all SourcePos occurences in the Syntax.hs with Position.