### PR TITLE
Type import fix.

### DIFF
--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -50,7 +50,7 @@ data Import a = Import
 data ImportedValue
     = ImportedIdentifier Identifier 
     -- ^ imported variable (e.g. '(>>=)', 'map')
-    | ImportedType TypeName [ConstructorName]
+    | ImportedType TypeName (Maybe [ConstructorName])
     -- ^ type and constructor import (e.g. Maybe(Nothing), Either(), Map(..))
   deriving Show
 
@@ -181,7 +181,7 @@ data Type
     | TupleType [Type]
     -- ^ tuple of types (e.g. '(Int, a, Float)')
     | ArrayType Type
-    -- ^ array of elements of concrete type (e.g '[|Int|]', [| [|Float|] |])
+    -- ^ array of elements of some type (e.g '[>Int<]', [>[>a<]<])
   deriving Show
 
 data PrimExpr

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -40,10 +40,11 @@ data Module a = Module
   deriving Show
 
 data Import a = Import
-    { importMod  :: Module a
-    , importName :: ModuleId
-    , importLoc  :: Position
-    , importIds  :: Maybe [Located ImportedValue]
+    { importMod   :: Module a
+    , importName  :: ModuleId
+    , importAlias :: Maybe ModName
+    , importLoc   :: Position
+    , importIds   :: Maybe [Located ImportedValue]
     }
   deriving Show
 


### PR DESCRIPTION
1. Changed the type of ImportedValue ImportedType case so that
the list of imported constructors can be Nothing.
- `Just [] `-- no constructor was imported
- `Just [Foo, Bar]` -- Foo and Bar constructors were imported
- `Nothing` -- no explicit import list -- everything gets imported.
2. Added an "importAlias" field to the Import type, which is supposed to
represent qualified module names (e.g. 'import Foo as Bar' means that the
import's alias is 'Bar')
3. Fixed the description of ArrayType.