### PR TITLE
Big changes in the AST

### DIFF
--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -204,9 +204,13 @@ data PrimExpr
 data Expr a
     = Primitive PrimExpr Position a
     | Var Identifier Position a
-    -- ^ an identifier
-    | ScopedName ModName Identifier Position a
-    -- ^ an explicitly qualified name (e.g. Foo\bar)
+    -- ^ an identifier (e.g. map, (++))
+    | Constructor ConstructorName Position a
+    -- ^ a constructor (e.g. Just, [], ::, Nothing)
+    | QualifiedVar ModName Identifier Position a
+    -- ^ an explicitly qualified identifier (e.g. Foo\bar)
+    | QualifiedConstructor ModName ConstructorName Position a
+    -- ^ an explicitly qualified constructor (e.g. Foo\Nothing)
     | And (Expr a) (Expr a) Position a
     -- ^ 'and' boolean operator with its left and right operands
     | Or (Expr a) (Expr a) Position a
@@ -218,7 +222,7 @@ data Expr a
     | LetIn (LetDef a) (Expr a) a
     -- ^ local definition. Binds only in the Expr following it. Does not
     --   store Position as it is stored both in Definition and (maybe) in Expr
-    | Lambda (Pattern a) (Expr a) (Maybe Identifier) Position a
+    | Lambda (Pattern a) (Expr a) (Maybe T.Text) Position a
     -- ^ lambda expression with the list of bindings (patterns) and
     --   the expression to evaluate upon the function call.
     --   May remember the name if it was defined in 'let'-definiiton.

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -120,10 +120,11 @@ data Constraint = Constraint
   deriving Show
 
 data Instance a = Instance
-    { instanceClass   :: TypeName
-    , instanceType    :: TypeSig
-    , instanceMembers :: [LetDef a]
-    , instanceLoc     :: Position
+    { instanceClass       :: TypeName
+    , instanceType        :: TypeSig
+    , instanceMembers     :: [LetDef a]
+    , instanceLoc         :: Position
+    , instanceConstraints :: [Constraint]
     }
   deriving Show
 

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -64,7 +64,7 @@ data TopLevelDef a
   deriving Show
 
 data LetDef a = LetDef
-    { letPattern :: LetPattern a
+    { letPattern :: Pattern a
     , letTypeSig :: Maybe TypeSig
     , letExpr    :: Expr a
     , letLoc     :: Position
@@ -117,14 +117,6 @@ data Instance a = Instance
     , instanceMembers :: [LetDef a]
     , instanceLoc     :: Position
     }
-  deriving Show
-
-data LetPattern a
-    = FuncPattern 
-        { letFuncName :: Identifier
-        , letFuncArgs :: [Pattern a]
-        }
-    | LetPattern (Pattern a)
   deriving Show
 
 data TypeSig = TypeSig

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -63,12 +63,20 @@ data TopLevelDef a
     | InstanceDef (Instance a)
   deriving Show
 
-data LetDef a = LetDef
+data Definition a = Definition
     { letPattern :: Pattern a
     , letTypeSig :: Maybe TypeSig
     , letExpr    :: Expr a
     , letLoc     :: Position
     }
+  deriving Show
+
+data LetDef a
+    = LetDef (Definition a)
+    -- ^ single non-recursive definition 
+    | LetRecDef [Definition a] Position
+    -- ^ a set of mutually recursive definitions.
+    --   contains the position of 'let-rec' keyword
   deriving Show
 
 data TAlias = TAlias
@@ -208,9 +216,7 @@ data Expr a
     -- ^ list of expressions to be evaluated in order
     | LetIn (LetDef a) (Expr a) a
     -- ^ local definition. Binds only in the Expr following it. Does not
-    --   store Position as it is stored both in LetDef and (maybe) in Expr
-    | MultiLetIn [LetDef a] (Expr a) a
-    -- ^ multiple mutually recursive local definitions.
+    --   store Position as it is stored both in Definition and (maybe) in Expr
     | Lambda [Pattern a] (Expr a) (Maybe Identifier) Position a
     -- ^ lambda expression with the list of bindings (patterns) and
     --   the expression to evaluate upon the function call.

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -204,8 +204,8 @@ data Expr a
     = Primitive PrimExpr Position a
     | Var Identifier Position a
     -- ^ an identifier
-    | ScopedName ModuleId Identifier Position a
-    -- ^ name from a module (e.g. `Foo.Bar.x`)
+    | ScopedName ModName Identifier Position a
+    -- ^ an explicitly qualified name (e.g. Foo\bar)
     | And (Expr a) (Expr a) Position a
     -- ^ 'and' boolean operator with its left and right operands
     | Or (Expr a) (Expr a) Position a
@@ -217,7 +217,7 @@ data Expr a
     | LetIn (LetDef a) (Expr a) a
     -- ^ local definition. Binds only in the Expr following it. Does not
     --   store Position as it is stored both in Definition and (maybe) in Expr
-    | Lambda [Pattern a] (Expr a) (Maybe Identifier) Position a
+    | Lambda (Pattern a) (Expr a) (Maybe Identifier) Position a
     -- ^ lambda expression with the list of bindings (patterns) and
     --   the expression to evaluate upon the function call.
     --   May remember the name if it was defined in 'let'-definiiton.
@@ -231,7 +231,7 @@ data Expr a
     | Match (Expr a) [MatchCase a] Position a
     -- ^ pattern matching of Expr with a list of patterns. First matching
     --   pattern is choosen.
-    | Extern FilePath T.Text Position a
+    | External FilePath T.Text Position a
     -- ^ used to import foreign functions from shared libraries.
     | Internal Identifier Position a
     -- ^ built-in compiler value.

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -122,7 +122,7 @@ data Constraint = Constraint
 data Instance a = Instance
     { instanceClass       :: TypeName
     , instanceType        :: TypeSig
-    , instanceMembers     :: [LetDef a]
+    , instanceMembers     :: [Definition a]
     , instanceLoc         :: Position
     , instanceConstraints :: [Constraint]
     }


### PR DESCRIPTION
Previously we had two types of patterns that were possible in a let definition:
- LetPattern (Pattern a)
- FuncPattern Identifier [Pattern a]

They were defined so that we could differentiate between 'let f x' and 'let x'. They are not needed anymore however, as the parser can desugar 'let f x = e' into 'let f := fn x => e'.
The let definition would be recursive (meaning that the defined name is bound in the definition body) if and only if the right side of the assignment is a lambda expression.

Lambdas were changed so that they can only have a single parameter.
All multi-parameter lambdas are desugared to unary functions so that
we get automatic currying for free. Since optimizations will be
performed on different type of internal representation, this change
won't really have a negative impact on the performance of the
compiled code.

Extern constructor was renamed to External.

ScopedName was changed so that the prefix can only be a ModName instead
of a full module path.
The reasoning is that we should only allow the usage of explicitly imported
modules. If the user haven't imported module Foo\Bar, then he shouldn't
be able to use Foo\Bar\foo in the code.
In the current (unfinished) implementation of the parser a lot of effort
is spent on finding and including the imported files. Random qualified
names from modules that haven't been imported add another difficulty to
the already complex parser.

This means the following code will be invalid:
```
module FooBar

let foo := Foo\Bar\foo
```
But the following will be valid:
```
module FooBar
import Foo\Bar as Foo

let foo := Foo\foo
```

It should be possible to have constraints in instance definitions
so I added a list of constraints to the instance type.