### PR TITLE
Changed TypeSig to Type in some places.

### DIFF
--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -84,7 +84,7 @@ data TAlias = TAlias
     , aliasParams :: [TypeVar]
     , aliasKind   :: Maybe KindSig
     , aliasType   :: Type
-    , alisLoc     :: Position
+    , aliasLoc    :: Position
     }
   deriving Show
 

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -83,7 +83,7 @@ data TAlias = TAlias
     { aliasName   :: TypeName
     , aliasParams :: [TypeVar]
     , aliasKind   :: Maybe KindSig
-    , aliasType   :: TypeSig
+    , aliasType   :: Type
     , alisLoc     :: Position
     }
   deriving Show
@@ -147,7 +147,7 @@ data PrimType
 data TypeCase
     = TypeCaseRecord ConstructorName RecordType Position
     -- ^ constructor of a record
-    | TypeCase ConstructorName [TypeSig] Position
+    | TypeCase ConstructorName [Type] Position
     -- ^ normal constructor (e.g. 'Just a')
   deriving (Show, Eq, Ord)
 
@@ -156,7 +156,7 @@ newtype RecordType = RecordType [RecordField] deriving (Show, Eq, Ord)
 
 data RecordField = RecordField
     { recordFieldName :: Identifier
-    , recordFieldType :: TypeSig
+    , recordFieldType :: Type
     }
   deriving (Show, Eq, Ord)
 


### PR DESCRIPTION
Previously we allowed TypeSig in type aliases and in constructors, which made
the following definitions valid:
```
alias Foo := Show a => a

type Bar with
     case Bar (Num a => a)
```
This wasn't supposed to be allowed so I fixed it by changing TypeSig to Type in
some places in the AST definition.